### PR TITLE
Fix broken test

### DIFF
--- a/core/test/microscope/core_test.clj
+++ b/core/test/microscope/core_test.clj
@@ -113,7 +113,7 @@
     (components/mocked
      (a-function)
      (with-out-str
-       (io/send! @queue {:payload "Some msg"})) => #"ERROR: Message\n\n\{:cid"))
+       (io/send! @queue {:payload "Some msg"})) => #"ERROR: Message\n\nCID:"))
 
   (fact "allows to pass parameters to mocked env"
     (components/mocked {:initial-state-val :some-initial-state}


### PR DESCRIPTION
DebugLogger prints the CID direct to stdout without encoding it first.