### PR TITLE
Passing meta to constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.1.3
+### Added
+* IO instances will now receive an additional parameter `:meta`, with the original
+message's metadata
+
 ## 0.1.2
 ### Changes
 * Better log displaying

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject microscope "0.1.2"
+(defproject microscope "0.1.3"
   :description "Microservice architecture for Clojure"
   :url "https://github.com/acessocard/microscope"
   :license {:name "Eclipse Public License"

--- a/src/microscope/core.clj
+++ b/src/microscope/core.clj
@@ -20,9 +20,11 @@
       (cid-gen 8))))
 
 (defn params-for-generators [msg-data]
-  (let [cid (get-in msg-data [:meta :cid])
+  (let [meta (:meta msg-data)
+        cid (:cid meta)
         new-cid (generate-cid cid)]
-    {:cid new-cid}))
+    {:cid new-cid
+     :meta (dissoc meta :cid)}))
 
 (def ^:private get-generators identity)
 


### PR DESCRIPTION
Will be used for RPC implementation on RabbitMQ (and probably for other sync data in the future).