### PR TITLE
Normalize logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 0.2.0
 ### Changes
 * Pass logger generator to components
+* When logging exceptions, format is a little different: will always log in two keys:
+`:exception` and `:backtrace`, both strings (fix bugs with ElasticSearch, conforms to
+a simple schema)
+
 ### Bugfix
 * Adds serializer to Throwable, not Exceptions
 * Adds a multimethod on microscope.io - `serialize-type` - that allows to serialize

--- a/src/microscope/core.clj
+++ b/src/microscope/core.clj
@@ -107,7 +107,7 @@ are the mocked microscope. Other parameters are dependend of each component impl
   (let [possible-params (first args)
         params (cond-> {:mocked true}
                        (map? possible-params) (merge possible-params))
-        mocked-comps (->> (get params :mocks {}))]
+        mocked-comps (get params :mocks {})]
     `(let [function# ~params-for-generators]
        (with-redefs [params-for-generators #(merge (function# %) ~params)
                      get-generators #(merge % ~mocked-comps)

--- a/src/microscope/logging.clj
+++ b/src/microscope/logging.clj
@@ -60,7 +60,9 @@ Type can be :info, :warning, :error or :fatal"))
       (println "CID:" cid)
       (print-kv data))))
 
-(generators/add-encoder java.lang.Class generators/encode-str)
+(generators/add-encoder java.lang.Class
+                        (fn [class writer]
+                          (generators/encode-str (.getName class) writer)))
 (generators/add-encoder java.lang.StackTraceElement
                         (fn [ste writer]
                           (generators/encode-str (clojure.string/join " " (stack->vector ste)) writer)))

--- a/test/microscope/core_test.clj
+++ b/test/microscope/core_test.clj
@@ -89,8 +89,19 @@
       (fact "logs an error using logger and CID to correlate things"
         (subscribe :queue (fn [f _] (future/map #(Integer/parseInt %) f)))
         (io/send! component "ten")
-        @log-output => (contains {:type :fatal, :data (contains {:cid string?
-                                                                 :ex anything})})))))
+        (:type @log-output) => :fatal
+        (:data @log-output) => (contains {:cid string?
+                                          :exception string?
+                                          :backtrace string?})
+        (-> @log-output :data :exception io/deserialize-msg)
+        => {:cause "For input string: \"ten\""
+            :via [{:type "java.lang.NumberFormatException"
+                   :message "For input string: \"ten\""
+                   :at ["java.lang.NumberFormatException" "forInputString"
+                        "NumberFormatException.java" 65]}]}
+
+        (-> @log-output :data :backtrace)
+        => #"java\.lang\.Integer\.parseInt \(Integer\.java:580\)\n"))))
 
 (fact "generates a healthcheck HTTP entrypoint"
   (let [last-msg (atom nil)

--- a/test/microscope/core_test.clj
+++ b/test/microscope/core_test.clj
@@ -1,4 +1,5 @@
 (ns microscope.core-test
+  (:refer-clojure :exclude [subs])
   (:require [midje.sweet :refer :all]
             [microscope.core :as components]
             [microscope.io :as io]
@@ -104,8 +105,7 @@
         => #"java\.lang\.Integer\.parseInt \(Integer\.java:580\)\n"))))
 
 (fact "generates a healthcheck HTTP entrypoint"
-  (let [last-msg (atom nil)
-        unhealthy-component (reify health/Healthcheck (unhealthy? [_] {:yes "I am"}))
+  (let [unhealthy-component (reify health/Healthcheck (unhealthy? [_] {:yes "I am"}))
         subscribe (components/subscribe-with :unhealthy (constantly unhealthy-component))
         http (http-client/service ":8081")
         _ (subscribe :healthcheck health/handle-healthcheck)

--- a/test/microscope/future_test.clj
+++ b/test/microscope/future_test.clj
@@ -47,7 +47,7 @@
 
 (facts "when listening to futures"
   (let [success (future/just 10)
-        failure (future/execute (throw (ex-info {:some "error"})))]
+        failure (future/execute (throw (ex-info "error" {:some "error"})))]
     (fact "listens to success"
       (with-promise
         (future/on-success (fn [_] (deliver promise :success)) success)) => :success)

--- a/test/microscope/logging_test.clj
+++ b/test/microscope/logging_test.clj
@@ -1,6 +1,5 @@
 (ns microscope.logging-test
   (:require [midje.sweet :refer :all]
-            [microscope.core :as components]
             [microscope.logging :as log]
             [cheshire.core :as cheshire]))
 

--- a/test/microscope/logging_test.clj
+++ b/test/microscope/logging_test.clj
@@ -4,7 +4,7 @@
             [microscope.logging :as log]
             [cheshire.core :as cheshire]))
 
-(def default-logger (log/default-logger-gen {}))
+(def default-logger (log/default-logger-gen {:cid "F"}))
 (def mocked-logger (log/default-logger-gen {:mocked true :cid "FOO"}))
 (facts "when logging"
   (fact "logs to STDOUT in JSON format"
@@ -12,13 +12,27 @@
       (cheshire/decode res true) => {:type "info"
                                      :message "foo"
                                      :additional "data"
-                                     :cid nil}))
+                                     :cid "F"}))
+
+  (fact "parses exception code"
+    (log/parse-exception (ex-info "example" {:foo "BAR"}))
+    => (just
+        {:cause "example"
+         :via [{:type clojure.lang.ExceptionInfo
+                :at ["clojure.core/ex-info" "invokeStatic" "core.clj" 4617]
+                :message "example"
+                :data {:foo "BAR"}}]
+         :data {:foo "BAR"}
+         :trace vector?}))
 
   (fact "logs exception"
     (let [res (with-out-str (log/error default-logger "Error!" :ex (ex-info "example" {:foo "BAR"})))
           json-map (cheshire/decode res true)]
-      json-map => (contains {:type "error" :message "Error!"})
-      (:ex json-map) => (contains {:cause "example" :data {:foo "BAR"} :trace #(string? %)})))
+      json-map => (just {:message "Error!"
+                         :cid "F"
+                         :type "error"
+                         :ex string?})
+      (:ex json-map) => #"\{.*\"cause\":\"example\""))
 
   (fact "debug logger prettifies exceptions"
     (let [res (with-out-str (log/fatal mocked-logger "Error!" :ex (ex-info "example" {:foo "BAR"})))]


### PR DESCRIPTION
* When logging exceptions, format is a little different: will always log in two keys: `:exception` and `:backtrace`, both strings (fix bugs with ElasticSearch, conforms to a simple schema)
